### PR TITLE
correction du filtre de dates

### DIFF
--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -8,9 +8,11 @@ class WorkshopsController < ApplicationController
         dates = (Date.strptime(params[:search][:starts_at], '%Y-%m-%d')..Date.strptime(params[:search][:ends_at], '%Y-%m-%d')).to_a
         @workshops = policy_scope(Workshop).where(status: 'en ligne').select { |workshop| workshop.dates.any? { |date| dates.include?(date) } }
       elsif params[:search][:starts_at].present?
-        @workshops = policy_scope(Workshop).where(status: 'en ligne').global_search(Date.strptime(params[:search][:starts_at], '%Y-%m-%d'))
+        dates = (Date.strptime(params[:search][:starts_at], '%Y-%m-%d')..Date.today + 1.months).to_a
+        @workshops = policy_scope(Workshop).where(status: 'en ligne').select { |workshop| workshop.dates.any? { |date| dates.include?(date) } }
       elsif params[:search][:ends_at].present?
-        @workshops = policy_scope(Workshop).where(status: 'en ligne').global_search(Date.strptime(params[:search][:ends_at], '%Y-%m-%d'))
+        dates = (Date.today..Date.strptime(params[:search][:ends_at], '%Y-%m-%d')).to_a
+        @workshops = policy_scope(Workshop).where(status: 'en ligne').select { |workshop| workshop.dates.any? { |date| dates.include?(date) } }
       else
         @workshops = policy_scope(Workshop).where(status: 'en ligne')
       end

--- a/app/views/workshops/_filters_modal.html.erb
+++ b/app/views/workshops/_filters_modal.html.erb
@@ -31,7 +31,7 @@
           <% end %>
         </div>
         <div>
-          <% if params[:search][:starts_at].present? %>
+          <% if params[:search][:ends_at].present? %>
             <%= f.input :ends_at, as: :string, required: false, input_html: {class: "datepicker", value: Date.strptime(params[:search][:ends_at], '%Y-%m-%d') }, placeholder: "À tout moment", label: "Jusqu'au" %>
           <% else %>
             <%= f.input :ends_at, as: :string, required: false, input_html: {class: "datepicker"}, placeholder: "À tout moment", label: "Jusqu'au" %>


### PR DESCRIPTION
Correction des problèmes lors de l'utilisation du filtre pour les dates : 

1/ On peut désormais saisir une seule date sans que ça bug (erreur de code entre starts_at et ends_at).

2/ Changement du code si on ne saisit qu'une seule date : 

 - Si l'utilisateur saisit une date "A partir de", cela lui proposera tous les ateliers disponibles entre la date qu'il a saisie et la date + 1 mois (on pourra changer si ça ne te plait pas)

 - Si l'utilisateur saisit une date "Jusqu'au", cela lui proposera tous les ateliers entre la date du jour et la date qu'il a saisie

Normalement tout fonctionne j'ai fait plusieurs tests.

A dispo pour en discuter si besoin.

Bises